### PR TITLE
Fix Jquery name on Bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
   "keywords": ["floatlabel", "float", "label"],
   "license": "MIT",
   "dependencies": {
-     "jQuery": "latest"
+     "jquery": "latest"
   },
   "development": {},
   "ignore": [


### PR DESCRIPTION
The official package of jQuery on Bower is "jquery". The "jQuery" package
is pointing to the original jQuery repo, which hasn't the bower.json file.