### PR TITLE
Input event to detect autocompletion

### DIFF
--- a/floatlabels.js
+++ b/floatlabels.js
@@ -75,7 +75,7 @@
                 if( !settings.slideInput ) {                    
                     thisElement.css({ 'padding-top' : this.inputPaddingTop });
                 }
-                thisElement.on('keyup blur change', function( e ) {
+                thisElement.on('keyup blur change input', function( e ) {
                     self.checkValue( e );
                 });
                 thisElement.on('blur', function() { thisElement.prev('label').css({ 'color' : self.settings.blurColor }); });


### PR DESCRIPTION
When a value is set with autocompletion (suggestion box for example), the floating label isn't shown.
The input event solves the problem.